### PR TITLE
Update BC DevTools setup for netstandard2.0 and net8.0

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -44,10 +44,17 @@ jobs:
             **/packages.lock.json
             nuget.config
 
-      - name: Setup BC DevTools
+      - name: Setup BC DevTools - netstandard2.0
         uses: ./.github/actions/setup-bc-devtools
         with:
-          version-number: '12.0.875970'
+          version-number: '12.0.779795'
+          target-path: 'Microsoft.Dynamics.BusinessCentral.Development.Tools\netstandard2.0'
+
+      - name: Setup BC DevTools - net8.0
+        uses: ./.github/actions/setup-bc-devtools
+        with:
+          version-number: '16.0.1463980'
+          target-path: 'Microsoft.Dynamics.BusinessCentral.Development.Tools\net8.0'
 
       - name: Restore
         run: dotnet restore src/RoslynTestKit.sln

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -42,10 +42,17 @@ jobs:
             **/packages.lock.json
             nuget.config
 
-      - name: Setup BC DevTools
+      - name: Setup BC DevTools - netstandard2.0
         uses: ./.github/actions/setup-bc-devtools
         with:
-          version-number: '12.0.875970'
+          version-number: '12.0.779795'
+          target-path: 'Microsoft.Dynamics.BusinessCentral.Development.Tools\netstandard2.0'
+
+      - name: Setup BC DevTools - net8.0
+        uses: ./.github/actions/setup-bc-devtools
+        with:
+          version-number: '16.0.1463980'
+          target-path: 'Microsoft.Dynamics.BusinessCentral.Development.Tools\net8.0'
 
       - name: Restore
         run: dotnet restore src/RoslynTestKit.sln

--- a/src/RoslynTestKit/RoslynTestKit.csproj
+++ b/src/RoslynTestKit/RoslynTestKit.csproj
@@ -18,29 +18,41 @@
     <PackageReference Include="DiffPlex" Version="1.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <Reference Include="Microsoft.Dynamics.Nav.CodeAnalysis">
-        <SpecificVersion>False</SpecificVersion>
-        <HintPath>..\..\Microsoft.Dynamics.BusinessCentral.Development.Tools\Microsoft.Dynamics.Nav.CodeAnalysis.dll</HintPath>
-        <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces">
-        <SpecificVersion>False</SpecificVersion>
-        <HintPath>..\..\Microsoft.Dynamics.BusinessCentral.Development.Tools\Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces.dll</HintPath>
-        <Private>False</Private>
-    </Reference>
   </ItemGroup>
 
+  <!-- ms-dynamics-smb.al-12.0.779795 with AssemblyFileVersion 12.0.11.58921 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="ApprovalTests" Version="5.4.4"
                       PrivateAssets="all"
                       ExcludeAssets="build;buildTransitive;analyzers;contentFiles;native;runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.1.0" />
+    <Reference Include="Microsoft.Dynamics.Nav.CodeAnalysis">
+        <SpecificVersion>False</SpecificVersion>
+        <HintPath>..\..\Microsoft.Dynamics.BusinessCentral.Development.Tools\netstandard2.0\Microsoft.Dynamics.Nav.CodeAnalysis.dll</HintPath>
+        <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces">
+        <SpecificVersion>False</SpecificVersion>
+        <HintPath>..\..\Microsoft.Dynamics.BusinessCentral.Development.Tools\netstandard2.0\Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces.dll</HintPath>
+        <Private>False</Private>
+    </Reference>
   </ItemGroup>
 
+  <!-- ms-dynamics-smb.al-16.0.1463980 with AssemblyFileVersion 16.0.22.22232 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="ApprovalTests" Version="5.8.0"
                       PrivateAssets="all"
                       ExcludeAssets="build;buildTransitive;analyzers;contentFiles;native;runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
+    <Reference Include="Microsoft.Dynamics.Nav.CodeAnalysis">
+        <SpecificVersion>False</SpecificVersion>
+        <HintPath>..\..\Microsoft.Dynamics.BusinessCentral.Development.Tools\net8.0\Microsoft.Dynamics.Nav.CodeAnalysis.dll</HintPath>
+        <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces">
+        <SpecificVersion>False</SpecificVersion>
+        <HintPath>..\..\Microsoft.Dynamics.BusinessCentral.Development.Tools\net8.0\Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces.dll</HintPath>
+        <Private>False</Private>
+    </Reference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Improved compatibility between netstandard2.0 and net8.0 by using the corresponding Microsoft.Dynamics.Nav.* assemblies.
+semver: minor