### PR TITLE
Implement reflection-based ProjectInfo creation for binary compatibility in AdhocWorkspace

### DIFF
--- a/src/RoslynTestKit/RoslynTestKit.csproj
+++ b/src/RoslynTestKit/RoslynTestKit.csproj
@@ -45,7 +45,6 @@
                       PrivateAssets="all"
                       ExcludeAssets="build;buildTransitive;analyzers;contentFiles;native;runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
     <Reference Include="Microsoft.Dynamics.Nav.CodeAnalysis">
         <SpecificVersion>False</SpecificVersion>
         <HintPath>..\..\Microsoft.Dynamics.BusinessCentral.Development.Tools\net8.0\Microsoft.Dynamics.Nav.CodeAnalysis.dll</HintPath>


### PR DESCRIPTION
Resolve binary compatibility issue caused by a breaking change in the ProjectInfo.Create method signature between version v17.0.28.6483 and v17.0.28.26016 of Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces.dll

+semver: minor