### PR TITLE
feat: add net10.0 target framework

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -37,7 +37,8 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
+
           cache: true
           cache-dependency-path: |
             **/*.csproj
@@ -55,6 +56,13 @@ jobs:
         with:
           version-number: '16.0.1463980'
           target-path: 'Microsoft.Dynamics.BusinessCentral.Development.Tools\net8.0'
+
+      # TODO: Bump version when net10.0 is released on marketplace
+      - name: Setup BC DevTools - net10.0
+        uses: ./.github/actions/setup-bc-devtools
+        with:
+          version-number: '17.0.2273547'
+          target-path: 'Microsoft.Dynamics.BusinessCentral.Development.Tools\net10.0'
 
       - name: Restore
         run: dotnet restore src/RoslynTestKit.sln

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
           cache: true
           cache-dependency-path: |
             **/*.csproj
@@ -53,6 +53,12 @@ jobs:
         with:
           version-number: '16.0.1463980'
           target-path: 'Microsoft.Dynamics.BusinessCentral.Development.Tools\net8.0'
+
+      - name: Setup BC DevTools - net10.0
+        uses: ./.github/actions/setup-bc-devtools
+        with:
+          version-number: '17.0.2273547'
+          target-path: 'Microsoft.Dynamics.BusinessCentral.Development.Tools\net10.0'
 
       - name: Restore
         run: dotnet restore src/RoslynTestKit.sln

--- a/src/RoslynTestKit/RoslynTestKit.csproj
+++ b/src/RoslynTestKit/RoslynTestKit.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net8.0;net10.0</TargetFrameworks>
     <PackageId>ALCops.RoslynTestKit</PackageId>
     <Title>RoslynTestKit</Title>
     <Description>A lightweight framework for creating unit tests for Roslyn diagnostic analyzers, code fixes and refactorings.</Description>
@@ -53,6 +53,25 @@
     <Reference Include="Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces">
         <SpecificVersion>False</SpecificVersion>
         <HintPath>..\..\Microsoft.Dynamics.BusinessCentral.Development.Tools\net8.0\Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces.dll</HintPath>
+        <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+
+  <!-- TODO: Bump version when net10.0 is released on marketplace -->
+  <!-- ms-dynamics-smb.al-17.0.2273547 -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="ApprovalTests" Version="5.8.0"
+                      PrivateAssets="all"
+                      ExcludeAssets="build;buildTransitive;analyzers;contentFiles;native;runtime" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
+    <Reference Include="Microsoft.Dynamics.Nav.CodeAnalysis">
+        <SpecificVersion>False</SpecificVersion>
+        <HintPath>..\..\Microsoft.Dynamics.BusinessCentral.Development.Tools\net10.0\Microsoft.Dynamics.Nav.CodeAnalysis.dll</HintPath>
+        <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces">
+        <SpecificVersion>False</SpecificVersion>
+        <HintPath>..\..\Microsoft.Dynamics.BusinessCentral.Development.Tools\net10.0\Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces.dll</HintPath>
         <Private>False</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
## Summary

Add `net10.0` as a third TFM alongside `netstandard2.1` and `net8.0`, matching the Analyzers project which now builds and tests against net10.0 BC DevTools.

## Changes

- **`RoslynTestKit.csproj`**: Added `net10.0` to `<TargetFrameworks>` with a conditional `ItemGroup` referencing BC DevTools v17.0.2273547 and `Microsoft.CodeAnalysis.Common` 4.14.0
- **CI workflows**: Added `Setup BC DevTools - net10.0` step and bumped .NET SDK to 10.0.x (builds all three TFMs)

## Why not drop net8.0?

RoslynTestKit is a published NuGet package. Removing net8.0 would break consumers still on net8.0. Each TFM links against its own BC DevTools build because Microsoft can change APIs between major versions.