### PR TITLE
fix: include ApprovalTests as transitive dependency

### DIFF
--- a/src/RoslynTestKit/RoslynTestKit.csproj
+++ b/src/RoslynTestKit/RoslynTestKit.csproj
@@ -24,8 +24,7 @@
   <!-- ms-dynamics-smb.al-12.0.779795 with AssemblyFileVersion 12.0.11.58921 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="ApprovalTests" Version="5.4.4"
-                      PrivateAssets="all"
-                      ExcludeAssets="build;buildTransitive;analyzers;contentFiles;native;runtime" />
+                      ExcludeAssets="build;buildTransitive" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.1.0" />
     <Reference Include="Microsoft.Dynamics.Nav.CodeAnalysis">
         <SpecificVersion>False</SpecificVersion>
@@ -42,8 +41,7 @@
   <!-- ms-dynamics-smb.al-16.0.1463980 with AssemblyFileVersion 16.0.22.22232 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="ApprovalTests" Version="5.8.0"
-                      PrivateAssets="all"
-                      ExcludeAssets="build;buildTransitive;analyzers;contentFiles;native;runtime" />
+                      ExcludeAssets="build;buildTransitive" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
     <Reference Include="Microsoft.Dynamics.Nav.CodeAnalysis">
         <SpecificVersion>False</SpecificVersion>
@@ -61,8 +59,7 @@
   <!-- ms-dynamics-smb.al-17.0.2273547 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="ApprovalTests" Version="5.8.0"
-                      PrivateAssets="all"
-                      ExcludeAssets="build;buildTransitive;analyzers;contentFiles;native;runtime" />
+                      ExcludeAssets="build;buildTransitive" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
     <Reference Include="Microsoft.Dynamics.Nav.CodeAnalysis">
         <SpecificVersion>False</SpecificVersion>


### PR DESCRIPTION
## Problem

`DiffHelper.TryToReportDiffWithExternalTool` throws `FileNotFoundException` for `ApprovalTests` assembly when consumer test projects hit a code-action diff mismatch. This is because ApprovalTests was marked with `PrivateAssets="all"` and its runtime assets were excluded.

## Fix

- Removed `PrivateAssets="all"` so ApprovalTests flows as a transitive dependency to consumers
- Changed `ExcludeAssets` to `"build;buildTransitive"` (retains exclusion of MSBuild targets that may affect deterministic compilation)
- Applied to all 3 TFM-specific ApprovalTests `PackageReference` entries (netstandard2.1, net8.0, net10.0)

## Verification

- Builds successfully for netstandard2.1 and net8.0 (net10.0 has pre-existing BC DevTools DLL issue locally, works in CI)
- `dotnet-validate` deterministic check expected to pass (build targets still excluded)