### PR TITLE
fix: cross-platform line ending normalization in CodeFix tests

### DIFF
--- a/src/RoslynTestKit/Verify.cs
+++ b/src/RoslynTestKit/Verify.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions;
-using Microsoft.Dynamics.Nav.CodeAnalysis.Text;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces;
 using RoslynTestKit.Utils;
 
@@ -35,10 +33,7 @@ namespace RoslynTestKit
 
             var sourceText = newDocument.GetTextAsync(CancellationToken.None).GetAwaiter().GetResult();
             var mergedDocumentBuilder = new StringBuilder();
-            var text = ConvertToLineEndingsAwareString(sourceText);
-
-            mergedDocumentBuilder.Append(text);
-
+            mergedDocumentBuilder.Append(sourceText.ToString());
 
             foreach (var doc in newDocument.Project.Documents.OrderByDescending(x => x.Name))
             {
@@ -47,12 +42,12 @@ namespace RoslynTestKit
                     mergedDocumentBuilder.AppendLine($"{Environment.NewLine}{BaseTestFixture.FileSeparator}");
 
                     var docSourceText = doc.GetTextAsync(CancellationToken.None).GetAwaiter().GetResult();
-                    var docText = ConvertToLineEndingsAwareString(sourceText);
-
-                    mergedDocumentBuilder.Append(docText);
+                    mergedDocumentBuilder.Append(docSourceText.ToString());
                 }
             }
-            var actualCode = mergedDocumentBuilder.ToString();
+
+            var actualCode = NormalizeLineEndings(mergedDocumentBuilder.ToString());
+            expectedCode = NormalizeLineEndings(expectedCode);
 
             if (actualCode != expectedCode)
             {
@@ -62,17 +57,9 @@ namespace RoslynTestKit
             }
         }
 
-        private static string ConvertToLineEndingsAwareString(SourceText sourceText)
+        private static string NormalizeLineEndings(string text)
         {
-            string text = sourceText.ToString();
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
-                RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                text = text.Replace("\r\n", "\n");
-            }
-
-            return text;
+            return text.Replace("\r\n", "\n");
         }
     }
 }


### PR DESCRIPTION
## Summary
- Normalize both actual and expected code to LF before comparison in `Verify.CodeAction()`, making HasFix tests stable across Windows, Linux, and macOS regardless of git `core.autocrlf` settings
- Replace platform-specific `ConvertToLineEndingsAwareString` (only normalized actual output on Linux/macOS) with unconditional `NormalizeLineEndings` applied to both sides
- Fix pre-existing bug where multi-document comparison reused the wrong `SourceText` variable (`sourceText` instead of `docSourceText`)

## Context

All 135 HasFix tests in ALCops Analyzers fail on Linux/WSL because:
1. `.al` fixture files have CRLF (from `git core.autocrlf=true`)
2. `ConvertToLineEndingsAwareString` strips CRLF→LF on the **actual** code fix output on Linux
3. The **expected** code from fixture files was never normalized
4. The comparison at line 57 (`actualCode != expectedCode`) compares LF vs CRLF → always fails

## Test plan
- [x] Built RoslynTestKit locally, copied DLL into Analyzers NuGet cache
- [x] Ran full Analyzers test suite: 1,108 tests, 0 failures (previously 135 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)