### PR TITLE
Apply ruleset to compilation so tests can enable default-disabled diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ Every `RoslynFixtureFactory.Create<T>()` overload accepts an optional config obj
 | `ThrowsWhenInputDocumentContainsError` | `bool` | `true` | Throw when the code under test has compiler errors. |
 | `References` | `IReadOnlyList<MetadataReference>` | empty | Extra metadata references added to the project. |
 | `AdditionalFiles` | `IReadOnlyList<AdditionalText>` | empty | Additional files exposed to analyzers (e.g. `.editorconfig`). |
-| `RuleSetPath` | `string?` | `null` | Path to a `.ruleset` file that controls diagnostic severity. |
+| `RuleSetPath` | `string?` | `null` | Path to a JSON ruleset file. Its general and per-rule diagnostic options are applied to the compilation, so it can change severities and **enable diagnostics that are `isEnabledByDefault: false`**. |
 | `PackageCachePaths` | `IReadOnlyList<string>` | empty | Directories containing `.app` packages the compiler resolves symbols from. |
 | `CompilationOptions` | `CompilationOptions?` | `null` | Override the default `CompilationOptions`. |
 | `ParseOptions` | `ParseOptions?` | `null` | Override the default `ParseOptions`. |
@@ -338,11 +338,26 @@ Every `RoslynFixtureFactory.Create<T>()` overload accepts an optional config obj
 
 #### Example: apply a ruleset to an analyzer test
 
+A ruleset is a JSON file. Its `action` values map to diagnostic severities
+(`Error`, `Warning`, `Info`, `Hidden`, `None`, `Default`). Setting a real
+severity also **enables a rule that is `isEnabledByDefault: false`**, which is the
+typical reason to use a ruleset in tests:
+
+```json
+{
+    "name": "Enable FlowFieldsShouldNotBeEditable",
+    "description": "Enables the rule for tests.",
+    "rules": [
+        { "id": "LC0001", "action": "Warning" }
+    ]
+}
+```
+
 ```csharp
 var fixture = RoslynFixtureFactory.Create<FlowFieldsShouldNotBeEditable>(
     new AnalyzerTestFixtureConfig
     {
-        RuleSetPath = @"rules\my.ruleset"
+        RuleSetPath = @"rules\my.ruleset.json"
     });
 
 fixture.HasDiagnosticAtAllMarkers(code, DiagnosticIds.FlowFieldsShouldNotBeEditable);

--- a/src/RoslynTestKit/BaseTestFixture.cs
+++ b/src/RoslynTestKit/BaseTestFixture.cs
@@ -9,7 +9,9 @@ using AdditionalText = Microsoft.Dynamics.Nav.CodeAnalysis.AdditionalText;
 using CompilationOptions = Microsoft.Dynamics.Nav.CodeAnalysis.CompilationOptions;
 using Document = Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces.Document;
 using LanguageNames = Microsoft.Dynamics.Nav.CodeAnalysis.LanguageNames;
+using NavDiagnostic = Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics.Diagnostic;
 using ParseOptions = Microsoft.Dynamics.Nav.CodeAnalysis.ParseOptions;
+using RuleSetResolver = Microsoft.Dynamics.Nav.CodeAnalysis.DiagnosticRules.RuleSetResolver;
 
 namespace RoslynTestKit
 {
@@ -75,6 +77,7 @@ namespace RoslynTestKit
             var frameworkReferences = CreateFrameworkMetadataReferences();
 
             var compilationOptions = CustomCompilationOptions ?? GetCompilationOptions(languageName);
+            compilationOptions = ApplyRuleSet(compilationOptions);
 
             var settings = new ProjectSettings
             {
@@ -115,6 +118,32 @@ namespace RoslynTestKit
                 LanguageNames.AL => new CompilationOptions(),
                 _ => throw new NotSupportedException($"Language {languageName} is not supported")
             };
+
+        /// <summary>
+        /// Loads the ruleset referenced by <see cref="RuleSetPath"/> (if any) and applies its
+        /// general and per-rule diagnostic options to the supplied <paramref name="options"/>.
+        /// This is what actually enables/disables diagnostics in tests; the platform does not apply
+        /// the ruleset to the compilation automatically when projects are built in-memory.
+        /// </summary>
+        private CompilationOptions ApplyRuleSet(CompilationOptions options)
+        {
+            if (string.IsNullOrEmpty(RuleSetPath))
+            {
+                return options;
+            }
+
+            var diagnostics = new List<NavDiagnostic>();
+            var ruleSet = RuleSetResolver.LoadFromFile(RuleSetPath, diagnostics, externalRulesetsEnabled: false);
+
+            if (diagnostics.Count > 0)
+            {
+                throw RoslynTestKitException.InvalidRuleSet(RuleSetPath, diagnostics);
+            }
+
+            return options
+                .WithGeneralDiagnosticOption(ruleSet.GeneralDiagnosticOption)
+                .WithSpecificDiagnosticOptions(ruleSet.SpecificDiagnosticOptions);
+        }
 
         protected virtual IEnumerable<MetadataReference> CreateFrameworkMetadataReferences()
         {

--- a/src/RoslynTestKit/RoslynTestKitException.cs
+++ b/src/RoslynTestKit/RoslynTestKitException.cs
@@ -135,5 +135,12 @@ namespace RoslynTestKit
                 $"FixAllProvider.GetFixAsync() returned null{keyInfo}. " +
                 "The FixAll operation produced no code action.");
         }
+
+        public static RoslynTestKitException InvalidRuleSet(string ruleSetPath, IReadOnlyList<Diagnostic> diagnostics)
+        {
+            var details = diagnostics.MergeWithNewLines(d => $"  [{d.Id}] {d.GetMessage()}");
+            return new RoslynTestKitException(
+                $"Failed to load ruleset '{ruleSetPath}'.\r\n{details}");
+        }
     }
 }


### PR DESCRIPTION
## Summary

`BaseTestFixture` exposed `RuleSetPath` via the fixture configs, but it was only forwarded to `ProjectInfo.RuleSetPath`. The in-memory `AdhocWorkspace` builds the compilation from `ProjectState.CompilationOptions` and **never applies the ruleset**, so `RuleSetPath` was effectively a no-op for diagnostics.

This change loads the ruleset and applies it to the compilation's diagnostic options, so tests can enable/disable diagnostics — in particular, enabling rules declared `isEnabledByDefault: false`.

## Changes

- `BaseTestFixture.CreateDocumentFromCode`: after computing `CompilationOptions`, call new `ApplyRuleSet(...)` helper.
- `ApplyRuleSet`: loads the ruleset via `RuleSetResolver.LoadFromFile(...)` and merges `GeneralDiagnosticOption` + `SpecificDiagnosticOptions` onto the options. Throws `RoslynTestKitException.InvalidRuleSet` on load errors.
- `RoslynTestKitException.InvalidRuleSet(...)`: new factory for clear failures on invalid/missing ruleset files.
- `README.md`: document that `RuleSetPath` is now applied, with a JSON ruleset example for enabling default-disabled diagnostics.

## Notes

- Uses public SDK APIs present in netstandard2.1, net8.0 and net10.0 — no `#if` guards needed.
- The existing `ProjectInfo.RuleSetPath` plumbing is left intact (harmless).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>