### PR TITLE
fix: resolve vulnerable transitive dependencies pulled in by ApprovalTests

### DIFF
--- a/src/RoslynTestKit/RoslynTestKit.csproj
+++ b/src/RoslynTestKit/RoslynTestKit.csproj
@@ -25,6 +25,16 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="ApprovalTests" Version="5.4.4"
                       ExcludeAssets="build;buildTransitive" />
+    <!-- ApprovalTests 5.4.4 (the last version with a netstandard asset) pins vulnerable transitive packages.
+         Direct references at the lowest patched version with a netstandard2.0 asset lift them; consumers inherit
+         the raised lower bounds through this package's nuspec. NU1903 GHSA-98g6-xh36-x2p7, NU1904 GHSA-rxg9-xrhp-64gj,
+         NU1903 GHSA-447r-wph3-92pm, NU1902 GHSA-9cxh-gqpx-qc5m, NU1902 GHSA-vh55-786g-wjwj, NU1903 GHSA-555c-2p6r-68mm. -->
+    <PackageReference Include="System.Data.SqlClient" Version="4.9.1" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.3" />
+    <PackageReference Include="System.Formats.Asn1" Version="6.0.1" />
+    <PackageReference Include="System.DirectoryServices.Protocols" Version="5.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="6.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.1.0" />
     <Reference Include="Microsoft.Dynamics.Nav.CodeAnalysis">
         <SpecificVersion>False</SpecificVersion>
@@ -40,7 +50,7 @@
 
   <!-- ms-dynamics-smb.al-16.0.1463980 with AssemblyFileVersion 16.0.22.22232 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="ApprovalTests" Version="5.8.0"
+    <PackageReference Include="ApprovalTests" Version="7.0.0"
                       ExcludeAssets="build;buildTransitive" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
     <Reference Include="Microsoft.Dynamics.Nav.CodeAnalysis">
@@ -58,7 +68,7 @@
   <!-- TODO: Bump version when net10.0 is released on marketplace -->
   <!-- ms-dynamics-smb.al-17.0.2273547 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="ApprovalTests" Version="5.8.0"
+    <PackageReference Include="ApprovalTests" Version="7.0.0"
                       ExcludeAssets="build;buildTransitive" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
     <Reference Include="Microsoft.Dynamics.Nav.CodeAnalysis">


### PR DESCRIPTION
Consumers of `ALCops.RoslynTestKit` (e.g. ALCops/Analyzers test projects) get `NU1903: System.Data.SqlClient 4.8.5 has a known high severity vulnerability` from `ApprovalTests → ApprovalUtilities`. This package's own restore additionally reports five more advisories on the netstandard2.1 chain. Nothing in this package (or in the AL compiler) loads any of these assemblies — they sit behind `DiffReporter` in the failure-reporting path — so this is about clean restores, not runtime behaviour.

## Changes (`src/RoslynTestKit/RoslynTestKit.csproj`)

| TFM | Change | Why |
|---|---|---|
| net8.0, net10.0 | `ApprovalTests` 5.8.0 → **7.0.0** (same `ExcludeAssets="build;buildTransitive"`) | 7.0.0's `ApprovalUtilities` depends on `System.Data.SqlClient >= 4.9.0` (patched), fixing it upstream. 7.0.0 ships a net8.0 asset, still contains `ApprovalTests.Reporters.DiffReporter` (the only type used, `Utils/DiffHelper.cs`) and has a smaller dependency set (no `Microsoft.Win32.Registry`). |
| netstandard2.1 | keep `ApprovalTests` 5.4.4; add direct references: `System.Data.SqlClient 4.9.1`, `System.Drawing.Common 5.0.3`, `System.Formats.Asn1 6.0.1`, `System.DirectoryServices.Protocols 5.0.1`, `System.Security.Cryptography.Xml 6.0.1`, `System.Security.Cryptography.Pkcs 6.0.3` | ApprovalTests 7 has no netstandard2.x asset, so the transitive pins are lifted directly. Each is the lowest patched version that still ships a `netstandard2.0` asset. Advisories: GHSA-98g6-xh36-x2p7, GHSA-rxg9-xrhp-64gj, GHSA-447r-wph3-92pm, GHSA-9cxh-gqpx-qc5m, GHSA-vh55-786g-wjwj, GHSA-555c-2p6r-68mm. |

Resulting nuspec: net8.0/net10.0 groups list `ApprovalTests >= 7.0.0`; the netstandard2.1 group lists `ApprovalTests >= 5.4.4` plus the six overrides, so consumers inherit the raised lower bounds.

## Verification

- `dotnet restore src/RoslynTestKit/RoslynTestKit.csproj` — no `NU19xx` on any TFM (was 7 lines).
- `dotnet build -c Release` — all three TFMs succeed (pre-existing nullable warnings unchanged).
- Pre-release check against **ALCops/Analyzers** with a local pack (`1.4.1-local`): solution restore audit-clean; `dotnet nuget why` shows `RoslynTestKit → ApprovalTests 7.0.0 → ApprovalUtilities 7.0.0 → System.Data.SqlClient 4.9.0`; all 1494 tests pass; the legacy `NavTargetFramework=netstandard2.1` restore is clean; `dotnet format --verify-no-changes` no longer prints "Warnings were encountered while loading the workspace" (that message was this advisory).
- Binding identity of `System.Data.SqlClient` is unchanged across the bump (4.8.5 → `4.6.1.5`, 4.9.1 → `4.6.1.6`).

Merging to `master` releases **1.4.1** via GitVersion Mainline; ALCops/Analyzers will bump to it in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
